### PR TITLE
Add build files

### DIFF
--- a/DirectXUTYs/D3_TEX.CPP
+++ b/DirectXUTYs/D3_TEX.CPP
@@ -42,6 +42,7 @@ FBOOL TexInit(void)
 	return flag;
 }
 
+/*
 FBOOL TexCreateTexture(char *filename,DWORD txid)
 {
 	HRESULT				dxret;
@@ -115,6 +116,7 @@ FBOOL TexCreateTexture(char *filename,DWORD txid)
 
 	return TRUE;
 }
+*/
 
 FVOID TexReleaseTexture(DWORD txid)
 {

--- a/DirectXUTYs/D3_TEX.H
+++ b/DirectXUTYs/D3_TEX.H
@@ -33,7 +33,7 @@ extern DXTEXTURE DxTex[TEXTURE_MAX];
 
 // 関数 //
 FBOOL TexInit(void);							// 最適なテクスチャフォーマットを検索する
-FBOOL TexCreateTexture(char *name,DWORD txid);	// テクスチャをロードする
+//FBOOL TexCreateTexture(char *name,DWORD txid);	// テクスチャをロードする
 FVOID TexReleaseTexture(DWORD txid);			// テクスチャを解放する
 FVOID TexSetTexture(DWORD txid);				// テクスチャハンドルをセットする
 

--- a/DirectXUTYs/DD_UTY.CPP
+++ b/DirectXUTYs/DD_UTY.CPP
@@ -579,8 +579,10 @@ static FVOID GrpFlipFS(void)
 	HRESULT		ddrval;
 
 	// キャプチャーフラグが有効かつ、キャプチャー要求が出ていれば画像を取り込む //
-	if(CaptureFlag && (GetAsyncKeyState(VK_SNAPSHOT)&0x8000))
-		PutSurfaceToBmp(DxObj.Back);
+	if (CaptureFlag && (GetAsyncKeyState(VK_SNAPSHOT) & 0x8000))
+		// TODO
+		//PutSurfaceToBmp(DxObj.Back);
+		;
 
 	// パレットを変更する必要があれば、変更だ //
 	if(DxObj.bNeedChgPal && DxObj.Bpp==8){
@@ -608,8 +610,10 @@ static FVOID GrpFlipWnd(void)
 	HRESULT		ddrval;
 
 	// キャプチャーフラグが有効かつ、キャプチャー要求が出ていれば画像を取り込む //
-	if(CaptureFlag && (GetAsyncKeyState(VK_SNAPSHOT)&0x8000))
-		PutSurfaceToBmp(DxObj.Back);
+	if (CaptureFlag && (GetAsyncKeyState(VK_SNAPSHOT) & 0x8000))
+		// TODO
+		//PutSurfaceToBmp(DxObj.Back);
+		;
 
 	for(;;){
 		ddrval = DxObj.Prim->Blt(NULL,DxObj.Back,NULL,0,NULL);

--- a/DirectXUTYs/DX_ERROR.C
+++ b/DirectXUTYs/DX_ERROR.C
@@ -22,7 +22,7 @@ extern void ErrSetup(void)
 }
 
 // エラー文字列を追加 //
-extern void ErrInsert(char *s)
+extern void ErrInsert(const char *s)
 {
 	ERROR_DATA *temp;
 
@@ -63,7 +63,7 @@ extern void ErrCleanup(void)
 	ErrSetup();
 }
 
-extern void DebugSetup(char *filename)
+extern void DebugSetup(const char *filename)
 {
 	char buf[1000];
 	FILE *fp;
@@ -88,7 +88,7 @@ extern void DebugCleanup(void)
 	//ErrorFP=NULL;
 }
 
-extern void DebugOut(char *s)
+extern void DebugOut(const char *s)
 {
 	FILE *fp;
 	fp= fopen(ErrorOut,"a");

--- a/DirectXUTYs/DX_ERROR.H
+++ b/DirectXUTYs/DX_ERROR.H
@@ -33,11 +33,11 @@ typedef struct _error{
 
 // 関数プロトタイプ宣言 //
 extern void ErrSetup(void);				// エラー用バッファの初期化
-extern void ErrInsert(char *s);			// エラー文字列を追加
+extern void ErrInsert(const char *s);			// エラー文字列を追加
 extern void ErrCleanup(void);			// エラー文字列出力＆メモリ解放
-extern void DebugSetup(char *filename);	// エラー出力準備(->LogFile)
+extern void DebugSetup(const char *filename);	// エラー出力準備(->LogFile)
 extern void DebugCleanup(void);			// エラー吐き出し用ファイルを閉じる
-extern void DebugOut(char *s);			// デバッグメッセージ吐き出し
+extern void DebugOut(const char *s);			// デバッグメッセージ吐き出し
 
 // C++ 対策 //
 #ifdef __cplusplus

--- a/GIAN07/BOSS.CPP
+++ b/GIAN07/BOSS.CPP
@@ -5,7 +5,7 @@
 
 #include "BOSS.h"
 #include "EnemyExCtrl.h"
-#include "..\\DirectX_UTYs\\DD_GRP3D.h"
+#include "../DirectXUTYs/DD_GRP3D.H"
 
 
 // 公開グローバル //

--- a/GIAN07/EFFECT.CPP
+++ b/GIAN07/EFFECT.CPP
@@ -165,7 +165,7 @@ FVOID SEffectInit(void)
 }
 
 // 文字列系エフェクト //
-FVOID StringEffect(int x,int y,char *s)
+FVOID StringEffect(int x,int y, const char *s)
 {
 	int		i,j,len;
 

--- a/GIAN07/EFFECT.H
+++ b/GIAN07/EFFECT.H
@@ -94,7 +94,7 @@ typedef struct tagSCREENEFC_INFO{
 
 ///// [ 関数 ] /////
 FVOID SEffectInit(void);								// エフェクトの初期化を行う
-FVOID StringEffect(int x,int y,char *s);				// 文字列系エフェクト(上に表示する奴)
+FVOID StringEffect(int x,int y, const char *s);				// 文字列系エフェクト(上に表示する奴)
 FVOID StringEffect2(int x,int y,DWORD point);			// 得点表示エフェクト
 FVOID StringEffect3(void);								// ゲームオーバーの表示
 FVOID SetMusicTitle(int y,char *s);						// 曲名の表示

--- a/GIAN07/FONTUTY.CPP
+++ b/GIAN07/FONTUTY.CPP
@@ -11,7 +11,7 @@ void __FillExpoint(EXPOINT *p, int x, int y, int w, int h);
 
 
 // 16x16 透過フォントで文字列出力(高速) //
-extern FVOID GrpPut16(int x,int y,char *s)
+extern FVOID GrpPut16(int x,int y,const char *s)
 {
 	RECT	src;
 	int		sx,tx,ty;

--- a/GIAN07/FONTUTY.H
+++ b/GIAN07/FONTUTY.H
@@ -46,7 +46,7 @@ typedef struct tagExtraFontInfo {
 
 
 ///// [ 関数 ] /////
-extern FVOID GrpPut16(int x,int y,char *s);		// 16x16 透過フォントで文字列出力(高速)
+extern FVOID GrpPut16(int x,int y,const char *s);		// 16x16 透過フォントで文字列出力(高速)
 extern FVOID GrpPut16c(int x,int y,char *s);	// 16x16 透過フォントで文字列出力(ｸﾘｯﾋﾟﾝｸﾞ有)
 extern FVOID GrpPut16c2(int x,int y,char *s);	// 上と同じだが、ｘ移動幅が１６
 extern FVOID GrpPutc(int x,int y,char c);		// 16x16 透過フォントで文字出力(ｸﾘｯﾋﾟﾝｸﾞ有)

--- a/GIAN07/GAMEMAIN.CPP
+++ b/GIAN07/GAMEMAIN.CPP
@@ -89,7 +89,7 @@ extern FBOOL ScoreNameInit(void)
 // スコアネームの表示 //
 FVOID ScoreNameProc(void)
 {
-	static char *ExString[5] = {"Easy","Normal","Hard","Lunatic","Extra"};
+	static const char *ExString[5] = {"Easy","Normal","Hard","Lunatic","Extra"};
 
 	Key_Read();
 

--- a/GIAN07/GIAN.CPP
+++ b/GIAN07/GIAN.CPP
@@ -229,7 +229,7 @@ extern FVOID StdStatusOutput(void)
 	static DWORD	fps,count;
 	static DWORD	time,temp;
 	//extern InputConfig			IConfig;
-	char	*DItem[4] = {"Easy","Norm","Hard","Luna"};
+	const char	*DItem[4] = {"Easy","Norm","Hard","Luna"};
 	char	buf[100];
 
 //	if(!DebugDat.MsgDisplay) return;

--- a/GIAN07/SCORE.CPP
+++ b/GIAN07/SCORE.CPP
@@ -11,7 +11,7 @@
 
 
 
-char *ScoreFileName = "秋霜SC.DAT";				// スコアデータ格納ファイル名
+const char *ScoreFileName = "秋霜SC.DAT";				// スコアデータ格納ファイル名
 NR_SCORE_STRING		ScoreString[NR_RANK_MAX];	// スコアデータ文字列格納先
 
 BYTE ExtraFlags = 0;

--- a/GIAN07/WindowCtrl.cpp
+++ b/GIAN07/WindowCtrl.cpp
@@ -103,7 +103,7 @@ WINDOW_INFO SndItem[4] = {
 };
 
 char IKeyTitle[4][20];
-char InpHelp[34] = "パッド上のボタンを押すと変更";
+char InpHelp[] = "パッド上のボタンを押すと変更";
 WINDOW_INFO InpKey[5] = {
 	{IKeyTitle[0],InpHelp, InpFnKeyTama,0,0},
 	{IKeyTitle[1],InpHelp, InpFnKeyBomb,0,0},
@@ -944,7 +944,7 @@ static BOOL CfgRepSave(WORD key)
 
 static void SetCfgRepItem(void)
 {
-	char *SWItem[2]  = {"[ O N ]","[O F F]"};
+	const char *SWItem[2]  = {"[ O N ]","[O F F]"};
 
 	if(0 == ConfigDat.StageSelect){
 		sprintf(CfgRepTitle[0], "ReplaySave  %s", SWItem[1]);
@@ -959,8 +959,8 @@ static void SetCfgRepItem(void)
 
 static void SetDifItem(void)
 {
-	char *DifItem[4] = {" Easy  "," Normal"," Hard  ","Lunatic"};
-	char *SWItem[2]  = {"[ O N ]","[O F F]"};
+	const char *DifItem[4] = {" Easy  "," Normal"," Hard  ","Lunatic"};
+	const char *SWItem[2]  = {"[ O N ]","[O F F]"};
 /*
 	{DifTitle[4],"[DebugMode] 画面に情報を表示するか"	,DifFnMsgDisplay,0,0},
 	{DifTitle[5],"[DebugMode] ステージセレクト"			,DifFnStgSelect,0,0},
@@ -980,8 +980,8 @@ static void SetDifItem(void)
 
 static void SetGrpItem(void)
 {
-	char	*UorD[3]  = {"上のほう","下のほう","描画せず"};
-	char	*DMode[4] = {"おまけ","60Fps","30Fps","20Fps"};
+	const char	*UorD[3]  = {"上のほう","下のほう","描画せず"};
+	const char	*DMode[4] = {"おまけ","60Fps","30Fps","20Fps"};
 	int		i;
 
 #define SetFlagsMacro(src,flag)		((flag) ? src[0] : src[1])
@@ -1000,7 +1000,7 @@ static void SetGrpItem(void)
 
 static void SetSndItem(void)
 {
-	char	*EorD[2] = {" 使用する ","使用しない"};
+	const char	*EorD[2] = {" 使用する ","使用しない"};
 	static int now;
 	char	*ptr,buf[1000];
 	int		l;

--- a/GIAN07/WindowSys.cpp
+++ b/GIAN07/WindowSys.cpp
@@ -341,7 +341,7 @@ void MWinDraw(void)
 }
 
 // メッセージ文字列を送る //
-void MWinMsg(char *s)
+void MWinMsg(const char *s)
 {
 	int			Line,i;
 

--- a/GIAN07/WindowSys.h
+++ b/GIAN07/WindowSys.h
@@ -68,8 +68,8 @@
 
 // 子ウィンドウの情報 //
 typedef struct tagWINDOW_INFO{
-	char			*Title;			// タイトル文字列へのポインタ(実体ではない！)
-	char			*Help;			// ヘルプ文字列へのポインタ(これも実体ではない)
+	const char			*Title;			// タイトル文字列へのポインタ(実体ではない！)
+	const char			*Help;			// ヘルプ文字列へのポインタ(これも実体ではない)
 
 	BOOL			(*CallBackFn)(WORD);	// 特殊処理用コールバック関数(未使用ならNULL)
 	BYTE			NumItems;				// 項目数(<ITEM_MAX)
@@ -106,7 +106,7 @@ typedef struct tagMSG_WINDOW{
 	BYTE		FaceState;			// 顔の状態
 	BYTE		FaceTime;			// 顔表示用カウンタ
 
-	char		*Msg[MSG_HEIGHT];	// 表示するメッセージへのポインタ
+	const char		*Msg[MSG_HEIGHT];	// 表示するメッセージへのポインタ
 
 	//char		MsgBuf[MSG_HEIGHT][MESSAGE_MAX];	// メッセージ格納配列の実体
 } MSG_WINDOW;
@@ -140,7 +140,7 @@ void MWinForceClose(void);		// メッセージウィンドウを強制クロー�
 void MWinMove(void);			// メッセージウィンドウを動作させる(後で上と統合する)
 void MWinDraw(void);			// メッセージウィンドウを描画する(上に同じ)
 
-void MWinMsg(char *s);			// メッセージ文字列を送る
+void MWinMsg(const char *s);			// メッセージ文字列を送る
 void MWinFace(BYTE faceID);		// 顔をセットする
 void MWinCmd(BYTE cmd);			// コマンドを送る
 

--- a/MAIN/MAIN.CPP
+++ b/MAIN/MAIN.CPP
@@ -1,4 +1,4 @@
-#include "..\\Gian07SrcFiles\\GIAN.h"
+#include "../GIAN07/GIAN.H"
 #include <direct.h>
 
 extern const char *APP_CLASS = "GIAN07";

--- a/patch/LZ_UTY.cpp
+++ b/patch/LZ_UTY.cpp
@@ -1,0 +1,810 @@
+#include <Windows.h>
+#include <io.h>
+#include "LZ_UTY.h"
+
+bool sub_421060(BIT_DEVICE *a1, BIT_DEVICE *a2, int a3);
+bool sub_421160(BIT_DEVICE *a1);
+void sub_421290(BIT_DEVICE *a1, int a2);
+void sub_421330(BIT_DEVICE *a1, int a2);
+void sub_421390(int a1);
+void sub_4213C0();
+int sub_4213F0(int a1, DWORD *a2);
+void sub_4214D0(int a1);
+void sub_421540(int a1, int a2);
+void sub_4215A0(int a1, int a2);
+int sub_421630(int a1);
+int sub_423080(BIT_DEVICE *a1);
+
+PBG_FILEHEAD FileHead;
+PBG_FILEINFO *FileInfo;
+uint32_t dword_4F0F40;
+char aScreenDBmp[0x100] = "Screen%d.BMP";
+uint8_t byte_4D6F38[0x2000];
+struct_4D8F38 unk_4D8F38[0x2000];
+
+BIT_DEVICE *FilStartR(const char *a1, int a2) {
+	if (a2)
+		return NULL;
+	BIT_DEVICE *v3 = BitFilCreate(a1, BD_FILE_READ);
+	if (sub_421160(v3))
+		return v3;
+	BitDevRelease(v3);
+	return NULL;
+}
+
+BIT_DEVICE *FilStartW(const char *a1, int a2, size_t a3) {
+	BIT_DEVICE *v4;
+	if (a2 != 1)
+		return 0;
+	v4 = BitFilCreate(a1, 1);
+	FileInfo = (PBG_FILEINFO *)LocalAlloc(0x40u, 12 * a3);
+	return v4;
+}
+
+void FilEnd(BIT_DEVICE *a1) {
+	BitDevRelease(a1);
+	LocalFree(FileInfo);
+}
+
+BYTE *MemExpand(BIT_DEVICE *a1, int a2) {
+	BYTE *result; // eax
+	BYTE *v3; // edi
+	BIT_DEVICE *v4; // esi
+
+	result = (BYTE *)LocalAlloc(0x40u, FileInfo[a2].m0);
+	v3 = result;
+	if (result)
+	{
+		v4 = BitMemCreate(result, 5, FileInfo[a2].m0);
+		if (!sub_421060(a1, v4, a2))
+		{
+			LocalFree(v3);
+			v3 = 0;
+		}
+		BitDevRelease(v4);
+		result = v3;
+	}
+	return result;
+}
+
+void Compress(BIT_DEVICE *a1, BIT_DEVICE *a2, int a3) {
+	BIT_DEVICE *v3; // edi
+	int v4; // ebp
+	signed int v5; // esi
+	int v6; // eax
+	signed int v7; // ebx
+	signed int v8; // esi
+	int v9; // eax
+	int v10; // esi
+	int v11; // eax
+	int v12; // [esp+10h] [ebp-Ch]
+	DWORD v13; // [esp+14h] [ebp-8h]
+	int v14; // [esp+18h] [ebp-4h]
+	int a2a; // [esp+24h] [ebp+8h]
+
+	v3 = a2;
+	a2->rack = 0;
+	a1->rack = 0;
+	a2->mask = 0x80;
+	a1->mask = 0x80;
+	a2->m4 = 0;
+	a1->m4 = 0;
+	v12 = 12 * a3;
+	FileInfo[a3].m1 = ftell(a2->p.file);
+	sub_4213C0();
+	v4 = 1;
+	v5 = 0;
+	do
+	{
+		v6 = sub_423080(a1);
+		if (v6 == -1)
+			break;
+		byte_4D6F38[++v5] = v6;
+	} while (v5 < 18);
+	a2a = v5;
+	sub_421390(1);
+	v7 = 0;
+	v13 = 0;
+	if (v5 > 0)
+	{
+		while (1)
+		{
+			if (v7 > a2a)
+				v7 = a2a;
+			if (v7 <= 2)
+				break;
+			PutBit(v3, 0);
+			PutBits(v3, v13, 13);
+			PutBits(v3, v7 - 3, 4);
+			v8 = v7;
+			if (v7 > 0)
+				goto LABEL_10;
+		LABEL_17:
+			if ((signed int)a2a <= 0)
+				goto LABEL_18;
+		}
+		v8 = 1;
+		PutBit(v3, 1u);
+		PutBits(v3, byte_4D6F38[v4], 8);
+	LABEL_10:
+		v14 = v8;
+		do
+		{
+			sub_4214D0((v4 + 18) & 0x1FFF);
+			v9 = sub_423080(a1);
+			if (v9 == -1)
+				--a2a;
+			else
+				byte_4D6F38[(v4 + 18) & 0x1FFF] = v9;
+			v4 = (v4 + 1) & 0x1FFF;
+			if (a2a)
+				v7 = sub_4213F0(v4, &v13);
+			--v14;
+		} while (v14);
+		goto LABEL_17;
+	}
+LABEL_18:
+	PutBit(v3, 0);
+	PutBits(v3, 0, 13);
+	if (v3->mask != 0x80)
+		PutChar(v3->rack, v3);
+	if (a1->m5 == BD_MEMORY_READ)
+	{
+		v10 = 12 * a3;
+		FileInfo[a3].m0 = a1->m6;
+	}
+	else
+	{
+		v11 = _fileno(a1->p.file);
+		v10 = 12 * a3;
+		FileInfo[a3].m0 = _filelength(v11);
+	}
+	FileInfo[a3].m2 = v3->m4;
+	sub_421330(v3, a3);
+	FileHead.sum += FileInfo[a3].m0 + FileInfo[a3].m1 + FileInfo[a3].m2;
+}
+
+bool sub_421060(BIT_DEVICE *a1, BIT_DEVICE *a2, int a3) {
+	BIT_DEVICE *v3; // ebx
+	int v4; // edi
+	int v5; // esi
+	uint8_t v6; // eax
+	char v7; // ST20_1
+	uint16_t v8; // eax
+	uint8_t v9; // eax
+	int v10; // ebp
+	int v11; // ebx
+	__int16 v13; // [esp+10h] [ebp-4h]
+
+	v3 = a1;
+	sub_421290(a1, a3);
+	v4 = 0;
+	a2->rack = 0;
+	a1->rack = 0;
+	a2->mask = 0x80;
+	a1->mask = 0x80;
+	a2->m4 = 0;
+	a1->m4 = 0;
+	sub_4213C0();
+	v5 = 1;
+	while (1)
+	{
+		while (GetBit(v3))
+		{
+			v6 = GetBits(v3, 8);
+			v7 = v6;
+			PutChar(v6, a2);
+			byte_4D6F38[v5] = v7;
+			v5 = ((WORD)v5 + 1) & 0x1FFF;
+		}
+		v8 = GetBits(v3, 13);
+		v13 = v8;
+		if (!v8)
+			break;
+		v9 = GetBits(v3, 4);
+		v10 = v9 + 2;
+		if (v9 + 2 >= 0)
+		{
+			do
+			{
+				v11 = (unsigned __int8)byte_4D6F38[((WORD)v4 + v13) & 0x1FFF];
+				PutChar(v11, a2);
+				byte_4D6F38[v5] = v11;
+				v5 = ((WORD)v5 + 1) & 0x1FFF;
+				++v4;
+			} while (v4 <= v10);
+			v3 = a1;
+			v4 = 0;
+		}
+	}
+	return FileInfo[a3].m2 == v3->m4;
+}
+
+bool sub_421160(BIT_DEVICE *a1) {
+	BIT_DEVICE *v1; // esi
+	PBG_FILEINFO *result; // eax
+	DWORD v3; // eax
+	int *v4; // eax
+	DWORD v5; // ecx
+	size_t v6; // edx
+	int v7; // esi
+	uint32_t *v8; // ecx
+	int v9; // edi
+	long v10;
+
+	v1 = a1;
+	if (!a1)
+		return 0;
+	v3 = a1->m5;
+	if (v3)
+	{
+		if (v3 == BD_MEMORY_READ)
+		{
+			v4 = (int *)a1->p.m0;
+			FileHead.name = *v4;
+			FileHead.sum = v4[1];
+			FileHead.n = v4[2];
+		}
+	}
+	else
+	{
+		v10 = ftell(a1->p.file);
+		fseek(v1->p.file, 0, 0);
+		fread(&FileHead.name, 0xCu, 1u, v1->p.file);
+	}
+	if (FileHead.name != PBG_HEADNAME)
+		return 0;
+	result = (PBG_FILEINFO *)LocalAlloc(0x40u, 12 * FileHead.n);
+	FileInfo = result;
+	if (result)
+	{
+		v5 = v1->m5;
+		if (v5)
+		{
+			if (v5 != BD_MEMORY_READ)
+			{
+			LABEL_15:
+				v6 = FileHead.n;
+				v7 = 0;
+				if (FileHead.n)
+				{
+					v8 = &result[0].m1;
+					do
+					{
+						v9 = *v8 + v8[1] + *(v8 - 1);
+						v8 += 3;
+						v7 += v9;
+						--v6;
+					} while (v6);
+				}
+				if (v7 == FileHead.sum)
+					return 1;
+				LocalFree(result);
+				return 0;
+			}
+			memcpy((void *)result, (const void *)(v1->m1 + 12), 12 * FileHead.n);
+		}
+		else
+		{
+			fread((void *)result, 0xCu, FileHead.n, v1->p.file);
+			fseek(v1->p.file, v10, 0);
+		}
+		result = FileInfo;
+		goto LABEL_15;
+	}
+	return result;
+}
+
+void sub_421290(BIT_DEVICE *a1, int a2) {
+	DWORD v2; // ecx
+	v2 = a1->m5;
+	if (v2)
+	{
+		if (v2 == BD_MEMORY_READ)
+			a1->p.m0 = a1->m1 + FileInfo[a2].m1;
+	}
+	else
+		fseek(a1->p.file, FileInfo[a2].m1, SEEK_SET);
+}
+
+void WriteHead(BIT_DEVICE *a1) {
+	int v1; // edi
+
+	if (a1->m5 == BD_FILE_WRITE)
+	{
+		v1 = ftell(a1->p.file);
+		fseek(a1->p.file, 0, 0);
+		fwrite(&FileHead.name, 0xC, 1, a1->p.file);
+		fseek(a1->p.file, v1, 0);
+	}
+}
+
+void sub_421330(BIT_DEVICE *a1, int a2)
+{
+	int v2; // ebx
+
+	if (a1->m5 == BD_FILE_WRITE)
+	{
+		v2 = ftell(a1->p.file);
+		fseek(a1->p.file, 4 * (3 * a2 + 3), 0);
+		fwrite(&FileInfo[a2], sizeof(FileInfo[a2]), 1, a1->p.file);
+		fseek(a1->p.file, v2, 0);
+	}
+}
+
+void sub_421390(int a1) {
+	dword_4F0F40 = a1;
+	unk_4D8F38[a1].m0 = 0x2000;
+	unk_4D8F38[a1].m2 = 0;
+	unk_4D8F38[a1].m1 = 0;
+}
+
+void sub_4213C0() {
+	memset(byte_4D6F38, 0, sizeof(byte_4D6F38));
+	memset(unk_4D8F38, 0, sizeof(unk_4D8F38));
+}
+
+int sub_4213F0(int a1, DWORD *a2) {
+	__int16 v2; // cx
+	signed int v3; // esi
+	signed int result; // eax
+	int v5; // ebx
+	__int16 v6; // di
+	int v7; // edx
+	int *v8; // edx
+	int v9; // ecx
+	signed int v10; // [esp+10h] [ebp-4h]
+
+	v2 = a1;
+	v3 = 0;
+	if (!a1)
+		return 0;
+	v5 = dword_4F0F40;
+	v10 = 0;
+	while (1)
+	{
+		v6 = v5 - v2;
+		do
+		{
+			v7 = byte_4D6F38[v2 & 0x1FFF] - byte_4D6F38[(v6 + v2) & 0x1FFF];
+			if (byte_4D6F38[v2 & 0x1FFF] != byte_4D6F38[(v6 + v2) & 0x1FFF])
+				break;
+			++v3;
+			++v2;
+		} while (v3 < 18);
+		result = v10;
+		if (v3 >= v10)
+		{
+			result = v3;
+			v10 = v3;
+			*a2 = v5;
+			if (v3 >= 18)
+			{
+				sub_4215A0(v5, a1);
+				return v3;
+			}
+		}
+		v3 = 0;
+		v8 = (int *)(v7 < 0 ? 12 * v5 + 5082940 : 12 * v5 + 5082944);
+		if (!*v8)
+			break;
+		v5 = *v8;
+		v2 = a1;
+	}
+	*v8 = a1;
+	unk_4D8F38[a1].m0 = v5;
+	unk_4D8F38[a1].m2 = 0;
+	unk_4D8F38[a1].m1 = 0;
+	return result;
+}
+
+void sub_4214D0(int a1)
+{
+	int v1; // eax
+	int v2; // edi
+
+	v1 = 3 * a1;
+	if (unk_4D8F38[a1].m0)
+	{
+		if (unk_4D8F38[a1].m2)
+		{
+			if (unk_4D8F38[a1].m1)
+			{
+				v2 = sub_421630(a1);
+				sub_4214D0(v2);
+				sub_4215A0(a1, v2);
+			}
+			else
+			{
+				sub_421540(a1, unk_4D8F38[a1].m2);
+			}
+		}
+		else
+		{
+			sub_421540(a1, unk_4D8F38[a1].m1);
+		}
+	}
+}
+
+void sub_421540(int a1, int a2)
+{
+	int v2; // eax
+
+	unk_4D8F38[a2].m0 = unk_4D8F38[a1].m0;
+	v2 = unk_4D8F38[a1].m0;
+	if (unk_4D8F38[v2].m2 == a1)
+		unk_4D8F38[v2].m2 = a2;
+	else
+		unk_4D8F38[v2].m1 = a2;
+	unk_4D8F38[a1].m0 = 0;
+}
+
+void sub_4215A0(int a1, int a2)
+{
+	int v2; // eax
+	struct_4D8F38 *v3; // esi
+
+	v2 = unk_4D8F38[a1].m0;
+	if (unk_4D8F38[v2].m1 == a1)
+		unk_4D8F38[v2].m1 = a2;
+	else
+		unk_4D8F38[v2].m2 = a2;
+	v3 = unk_4D8F38 + a2;
+	v3->m0 = unk_4D8F38[a1].m0;
+	v3->m1 = unk_4D8F38[a1].m1;
+	v3->m2 = unk_4D8F38[a1].m2;
+	unk_4D8F38[unk_4D8F38[a2].m1].m0 = a2;
+	unk_4D8F38[unk_4D8F38[a2].m2].m0 = a2;
+	unk_4D8F38[a1].m0 = 0;
+}
+
+int sub_421630(int a1)
+{
+	int result; // eax
+	int i; // ecx
+
+	result = unk_4D8F38[a1].m1;
+	for (i = unk_4D8F38[result].m2; i; i = unk_4D8F38[i].m2)
+		result = i;
+	return result;
+}
+
+BIT_DEVICE *BitFilCreate(const char *a1, int a2)
+{
+	BIT_DEVICE *v2; // esi
+	char v3; // cl
+	FILE *v4; // eax
+	const char *v6; // [esp+Ch] [ebp-4h]
+
+	v2 = (BIT_DEVICE *)malloc(0x20u);
+	if (!v2)
+		return NULL;
+
+	switch (a2)
+	{
+	case BD_FILE_READ:
+		v6 = "rb";
+		break;
+	case BD_FILE_WRITE:
+		v6 = "wb";
+		break;
+	case 2:
+		v6 = "rb";
+		break;
+	case 3:
+		v6 = "wb";
+		break;
+	default:
+		free(v2);
+		return 0;
+	}
+	v2->p.file = fopen(a1, v6);
+	if (!v2->p.file) {
+		free(v2);
+		return 0;
+	}
+	v2->m1 = 0;
+	v2->mask = 0x80;
+	v2->rack = 0;
+	v2->m4 = 0;
+	v2->m5 = a2;
+	v2->m6 = 0;
+	v2->m7 = 0;
+	return v2;
+}
+
+BIT_DEVICE *BitMemCreate(BYTE *a1, int a2, size_t a3) {
+	BIT_DEVICE *result; // eax
+	result = (BIT_DEVICE *)malloc(0x20u);
+	if (result)
+	{
+		if (a2 >= 4 && a2 <= 7)
+		{
+			result->p.m0 = a1;
+			result->m1 = a1;
+			result->mask = 0x80;
+			result->rack = 0;
+			result->m4 = 0;
+			result->m5 = a2;
+			result->m6 = a3;
+			result->m7 = 0;
+			return result;
+		}
+		free(result);
+	}
+	return 0;
+}
+
+void BitDevRelease(BIT_DEVICE *a1) {
+	if (a1) {
+		switch (a1->m5)
+		{
+		case 0:
+		case 1:
+		case 2:
+		case 3:
+			fclose(a1->p.file);
+		case 4:
+		case 5:
+		case 6:
+		case 7:
+			free(a1);
+		}
+	}
+}
+
+void PutBit(BIT_DEVICE *a1, BYTE a2) {
+	char v2; // al
+	unsigned __int8 *v3; // edx
+	int v4; // eax
+	int v5; // eax
+	int v6; // ecx
+
+	if (a2)
+		a1->rack |= a1->mask;
+	v2 = a1->mask >> 1;
+	a1->mask = v2;
+	if (!v2)
+	{
+		if (a1->m5 == BD_FILE_WRITE)
+		{
+			putc(a1->rack, a1->p.file);
+		}
+		else
+		{
+			if (a1->m5 != 5)
+				return;
+			*(a1->p.m0)++ = (a1->rack);
+		}
+		v5 = a1->rack;
+		v6 = a1->m4;
+		a1->rack = 0;
+		a1->m4 = v5 + v6;
+		a1->mask = 0x80;
+	}
+}
+
+void PutBits(BIT_DEVICE *a1, DWORD a2, int a3) {
+	unsigned int v3; // edi
+	char v4; // cl
+	DWORD v5; // ecx
+	DWORD v6; // edx
+	char v7; // al
+	unsigned __int8 *v8; // edx
+	int v9; // eax
+	DWORD v10; // ecx
+	DWORD v11; // eax
+
+	v3 = 1 << (a3 - 1);
+	if (a1->m5 == BD_FILE_WRITE)
+	{
+		for (; v3; v3 >>= 1)
+		{
+			if (v3 & a2)
+				a1->rack |= a1->mask;
+			v7 = a1->mask >> 1;
+			a1->mask = v7;
+			if (!v7)
+			{
+				putc(a1->rack, a1->p.file);
+				v10 = a1->rack;
+				v11 = a1->m4;
+				a1->rack = 0;
+				a1->m4 = v10 + v11;
+				a1->mask = 0x80;
+			}
+		}
+	}
+	else if (a1->m5 == 5 && v3)
+	{
+		do
+		{
+			if (v3 & a2)
+				a1->rack |= a1->mask;
+			v4 = a1->mask >> 1;
+			a1->mask = v4;
+			if (!v4)
+			{
+				*(a1->p.m0) = a1->rack;
+				v5 = a1->m4;
+				++(a1->p.m0);
+				v6 = a1->rack;
+				a1->rack = 0;
+				a1->m4 = v6 + v5;
+				a1->mask = -128;
+			}
+			v3 >>= 1;
+		} while (v3);
+	}
+}
+
+void PutChar(uint32_t a1, BIT_DEVICE *a2) {
+	switch (a2->m5)
+	{
+	case BD_FILE_WRITE:
+	case 3:
+		fputc(a1, a2->p.file);
+		break;
+	case 5:
+	case 7:
+		*(a2->p.m0) = a1;
+		(a2->p.m0)++;
+		break;
+	default:
+		return;
+	}
+}
+
+BYTE GetBit(BIT_DEVICE *a1) {
+	int v1; // eax
+	unsigned int v3; // ecx
+	int v4; // edx
+	DWORD *v5; // ecx
+	int v6; // eax
+	int v7; // eax
+	char v8; // cl
+
+	v1 = a1->m5;
+	if (v1)
+	{
+		if (v1 != BD_MEMORY_READ)
+			return 0;
+		if (a1->mask == 0x80)
+		{
+			v3 = a1->m7;
+			if (v3 >= a1->m6)
+			{
+				return 0;
+			}
+			v4 = *(a1->p.m0)++;
+			a1->rack= v4;
+			a1->m4 += v4;
+			a1->m7 = v3 + 1;
+		}
+	}
+	else if (a1->mask == 0x80)
+	{
+		v6 = getc(a1->p.file);
+		a1->rack = v6;
+		if (v6 == -1)
+		{
+			return 0;
+		}
+		a1->m4 += v6;
+	}
+	v7 = a1->mask & a1->rack;
+	v8 = a1->mask >> 1;
+	a1->mask = v8;
+	if (!v8)
+		a1->mask = 0x80;
+	return v7 != 0;
+}
+
+/*
+WORD GetBits(BIT_DEVICE *a1, int a2) {
+	DWORD v2; // eax
+	WORD v3; // bx
+	unsigned int v4; // edi
+	unsigned __int8 v6; // al
+	DWORD v7; // ebp
+	DWORD v8; // edx
+	char v9; // al
+	DWORD *v10; // ecx
+	int v11; // eax
+	unsigned __int8 v12; // al
+	char v13; // al
+
+	v2 = a1->m5;
+	v3 = 0;
+	v4 = 1 << (a2 - 1);
+	if (v2)
+	{
+		if (v2 != BD_MEMORY_READ)
+			return 0;
+		while (v4)
+		{
+			v6 = a1->mask;
+			if (v6 == 0x80)
+			{
+				v7 = a1->m7;
+				if (v7 >= a1->m6)
+				{
+					return 0;
+				}
+				v8 = *(a1->p.m0)++;
+				a1->rack = v8;
+				a1->m4 += v8;
+				a1->m7 = v7 + 1;
+			}
+			if (v6 & (uint8_t)(a1->rack))
+				v3 |= v4;
+			v4 >>= 1;
+			v9 = v6 >> 1;
+			a1->mask = v9;
+			if (!v9)
+				a1->mask = 0x80;
+		}
+		return v3;
+	}
+	if (!v4)
+		return v3;
+	for (;;)
+	{
+		v12 = a1->mask;
+		if ((uint8_t)(a1->rack) & v12)
+			v3 |= v4;
+		v4 >>= 1;
+		v13 = v12 >> 1;
+		a1->mask = v13;
+		if (!v13) {
+			a1->mask = 0x80;
+			v11 = getc(a1->p.file);
+			a1->rack = v11;
+			if (v11 != -1)
+				a1->m4 += v11;
+			else
+				return 0;
+		}
+		if (!v4)
+			return v3;
+	}
+}
+*/
+
+WORD GetBits(BIT_DEVICE *a1, int a2) {
+	WORD ret = 0;
+	while (a2--) {
+		ret = ret * 2 + GetBit(a1);
+	}
+	return ret;
+}
+
+int sub_423080(BIT_DEVICE *a1) {
+	int result; // eax
+	DWORD v2; // esi
+
+	switch (a1->m5)
+	{
+	case BD_FILE_READ:
+	case 2:
+		return getc(a1->p.file);
+	case BD_MEMORY_READ:
+	case 6:
+		v2 = a1->m7;
+		if (v2 < a1->m6)
+		{
+			result = *(a1->p.m0)++;
+			a1->m7 = v2 + 1;
+		}
+		else
+			result = -1;
+		return result;
+	default:
+		return 0;
+	}
+}
+
+void GrpSetCaptureFilename(const char *a1) {
+	sprintf(aScreenDBmp, "%.4s%%04d.BMP", a1);
+	CaptureFlag = 1;
+}

--- a/patch/LZ_UTY.h
+++ b/patch/LZ_UTY.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+
+#define BD_FILE_READ 0
+#define BD_FILE_WRITE 1
+#define BD_MEMORY_READ 4
+
+#define PBG_HEADNAME 0x1A474250
+
+typedef struct {
+	union {
+		FILE *file;
+		BYTE *m0;
+	} p;
+	BYTE *m1;
+	unsigned char mask;
+	uint32_t rack;
+	uint32_t m4;
+	uint32_t m5;
+	size_t m6;
+	uint32_t m7;
+} BIT_DEVICE;
+
+typedef struct {
+	uint32_t name;
+	uint32_t sum;
+	size_t n;
+} PBG_FILEHEAD;
+
+typedef struct {
+	uint32_t m0;
+	uint32_t m1;
+	uint32_t m2;
+} PBG_FILEINFO;
+
+typedef PBG_FILEINFO struct_4D8F38;
+
+extern PBG_FILEHEAD FileHead;
+extern PBG_FILEINFO *FileInfo;
+extern char aScreenDBmp[0x100];
+extern BOOL CaptureFlag;
+
+BIT_DEVICE *FilStartR(const char *a1, int a2);
+BIT_DEVICE *FilStartW(const char *a1, int a2, size_t a3);
+void FilEnd(BIT_DEVICE *a1);
+#ifdef __cplusplus
+extern "C" BYTE *MemExpand(BIT_DEVICE *a1, int a2);
+#else
+BYTE *MemExpand(BIT_DEVICE *a1, int a2);
+#endif
+void Compress(BIT_DEVICE *a1, BIT_DEVICE *a2, int a3);
+void WriteHead(BIT_DEVICE *a1);
+BIT_DEVICE *BitFilCreate(const char *a1, int a2);
+BIT_DEVICE *BitMemCreate(BYTE *a1, int a2, size_t a3);
+void BitDevRelease(BIT_DEVICE *a1);
+void PutBit(BIT_DEVICE *a1, BYTE a2);
+void PutBits(BIT_DEVICE *a1, DWORD a2, int a3);
+void PutChar(uint32_t a1, BIT_DEVICE *a2);
+BYTE GetBit(BIT_DEVICE *a1);
+WORD GetBits(BIT_DEVICE *a1, int a2);
+void GrpSetCaptureFilename(const char *a1);

--- a/vs/秋霜玉.sln
+++ b/vs/秋霜玉.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.329
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "秋霜玉", "秋霜玉.vcxproj", "{DD948C1B-D49E-44C9-943A-7DEC8050B1D4}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x86 = Debug|x86
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{DD948C1B-D49E-44C9-943A-7DEC8050B1D4}.Debug|x86.ActiveCfg = Debug|Win32
+		{DD948C1B-D49E-44C9-943A-7DEC8050B1D4}.Debug|x86.Build.0 = Debug|Win32
+		{DD948C1B-D49E-44C9-943A-7DEC8050B1D4}.Release|x86.ActiveCfg = Release|Win32
+		{DD948C1B-D49E-44C9-943A-7DEC8050B1D4}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {11419C44-DD3B-4957-B8BB-37434751EFA7}
+	EndGlobalSection
+EndGlobal

--- a/vs/秋霜玉.vcxproj
+++ b/vs/秋霜玉.vcxproj
@@ -1,0 +1,231 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>15.0</VCProjectVersion>
+    <ProjectGuid>{DD948C1B-D49E-44C9-943A-7DEC8050B1D4}</ProjectGuid>
+    <RootNamespace>秋霜玉</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>false</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <PreprocessorDefinitions>DIRECTDRAW_VERSION=0x0700;DIRECTSOUND_VERSION=0x0700;DIRECTINPUT_VERSION=0x0700;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\DirectXUTYs;..\patch;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <AdditionalLibraryDirectories>../patch;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>false</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <PreprocessorDefinitions>DIRECTDRAW_VERSION=0x0700;DIRECTSOUND_VERSION=0x0700;DIRECTINPUT_VERSION=0x0700;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\DirectXUTYs;..\patch;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <AdditionalLibraryDirectories>../patch;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>false</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <PreprocessorDefinitions>DIRECTDRAW_VERSION=0x0700;DIRECTSOUND_VERSION=0x0700;DIRECTINPUT_VERSION=0x0700;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\DirectXUTYs;..\patch;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>../patch;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>false</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <PreprocessorDefinitions>DIRECTDRAW_VERSION=0x0700;DIRECTSOUND_VERSION=0x0700;DIRECTINPUT_VERSION=0x0700;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\DirectXUTYs;..\patch;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>../patch;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\DirectXUTYs\D2_Polygon.CPP" />
+    <ClCompile Include="..\DirectXUTYs\D3_TEX.CPP" />
+    <ClCompile Include="..\DirectXUTYs\DD_CLIP2D.CPP" />
+    <ClCompile Include="..\DirectXUTYs\DD_GRP2D.CPP" />
+    <ClCompile Include="..\DirectXUTYs\DD_GRP3D.CPP" />
+    <ClCompile Include="..\DirectXUTYs\DD_UTY.CPP" />
+    <ClCompile Include="..\DirectXUTYs\DI_UTY.CPP" />
+    <ClCompile Include="..\DirectXUTYs\DS_UTY.CPP" />
+    <ClCompile Include="..\DirectXUTYs\DX_ERROR.C" />
+    <ClCompile Include="..\DirectXUTYs\PBGMIDI.C" />
+    <ClCompile Include="..\DirectXUTYs\UT_MATH.C" />
+    <ClCompile Include="..\GIAN07\BOMBEFC.CPP" />
+    <ClCompile Include="..\GIAN07\BOSS.CPP" />
+    <ClCompile Include="..\GIAN07\DEMOPLAY.CPP" />
+    <ClCompile Include="..\GIAN07\EFFECT.CPP" />
+    <ClCompile Include="..\GIAN07\EFFECT3D.CPP" />
+    <ClCompile Include="..\GIAN07\ENDING.CPP" />
+    <ClCompile Include="..\GIAN07\ENEMY.CPP" />
+    <ClCompile Include="..\GIAN07\EnemyExCtrl.cpp" />
+    <ClCompile Include="..\GIAN07\FONTUTY.CPP" />
+    <ClCompile Include="..\GIAN07\FRAGMENT.CPP" />
+    <ClCompile Include="..\GIAN07\GAMEMAIN.CPP" />
+    <ClCompile Include="..\GIAN07\GIAN.CPP" />
+    <ClCompile Include="..\GIAN07\HOMINGL.CPP" />
+    <ClCompile Include="..\GIAN07\ITEM.CPP" />
+    <ClCompile Include="..\GIAN07\LASER.CPP" />
+    <ClCompile Include="..\GIAN07\LENS.CPP" />
+    <ClCompile Include="..\GIAN07\LLASER.CPP" />
+    <ClCompile Include="..\GIAN07\LOADER.CPP" />
+    <ClCompile Include="..\GIAN07\MAID.CPP" />
+    <ClCompile Include="..\GIAN07\MAIDTAMA.CPP" />
+    <ClCompile Include="..\GIAN07\PaletteEX.cpp" />
+    <ClCompile Include="..\GIAN07\PRankCtrl.cpp" />
+    <ClCompile Include="..\GIAN07\SCORE.CPP" />
+    <ClCompile Include="..\GIAN07\SCROLL.CPP" />
+    <ClCompile Include="..\GIAN07\TAMA.CPP" />
+    <ClCompile Include="..\GIAN07\WindowCtrl.cpp" />
+    <ClCompile Include="..\GIAN07\WindowSys.cpp" />
+    <ClCompile Include="..\MAIN\MAIN.CPP" />
+    <ClCompile Include="..\patch\LZ_UTY.cpp" />
+    <ClCompile Include="..\patch\MtoB.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\DirectXUTYs\D2_Polygon.H" />
+    <ClInclude Include="..\DirectXUTYs\D3_TEX.H" />
+    <ClInclude Include="..\DirectXUTYs\DD_CLIP2D.H" />
+    <ClInclude Include="..\DirectXUTYs\DD_GRP2D.H" />
+    <ClInclude Include="..\DirectXUTYs\DD_GRP3D.H" />
+    <ClInclude Include="..\DirectXUTYs\DD_UTY.H" />
+    <ClInclude Include="..\DirectXUTYs\DI_UTY.H" />
+    <ClInclude Include="..\DirectXUTYs\DS_UTY.H" />
+    <ClInclude Include="..\DirectXUTYs\DX_ERROR.H" />
+    <ClInclude Include="..\DirectXUTYs\DX_TYPE.H" />
+    <ClInclude Include="..\DirectXUTYs\PBGMIDI.H" />
+    <ClInclude Include="..\DirectXUTYs\PBGUTY_X.H" />
+    <ClInclude Include="..\DirectXUTYs\UT_MATH.H" />
+    <ClInclude Include="..\GIAN07\BOMBEFC.H" />
+    <ClInclude Include="..\GIAN07\BOSS.H" />
+    <ClInclude Include="..\GIAN07\DEMOPLAY.H" />
+    <ClInclude Include="..\GIAN07\ECL.H" />
+    <ClInclude Include="..\GIAN07\ECL_LEN.H" />
+    <ClInclude Include="..\GIAN07\EFFECT.H" />
+    <ClInclude Include="..\GIAN07\EFFECT3D.H" />
+    <ClInclude Include="..\GIAN07\ENDING.H" />
+    <ClInclude Include="..\GIAN07\ENEMY.H" />
+    <ClInclude Include="..\GIAN07\EnemyExCtrl.h" />
+    <ClInclude Include="..\GIAN07\EXDEF.H" />
+    <ClInclude Include="..\GIAN07\FONTUTY.H" />
+    <ClInclude Include="..\GIAN07\FRAGMENT.H" />
+    <ClInclude Include="..\GIAN07\GAMEMAIN.H" />
+    <ClInclude Include="..\GIAN07\GIAN.H" />
+    <ClInclude Include="..\GIAN07\HOMINGL.H" />
+    <ClInclude Include="..\GIAN07\ITEM.H" />
+    <ClInclude Include="..\GIAN07\LASER.H" />
+    <ClInclude Include="..\GIAN07\LENS.H" />
+    <ClInclude Include="..\GIAN07\LLASER.H" />
+    <ClInclude Include="..\GIAN07\LOADER.H" />
+    <ClInclude Include="..\GIAN07\MAID.H" />
+    <ClInclude Include="..\GIAN07\MAIDTAMA.H" />
+    <ClInclude Include="..\GIAN07\PaletteEx.h" />
+    <ClInclude Include="..\GIAN07\PRankCtrl.h" />
+    <ClInclude Include="..\GIAN07\SCL.H" />
+    <ClInclude Include="..\GIAN07\SCORE.H" />
+    <ClInclude Include="..\GIAN07\SCROLL.H" />
+    <ClInclude Include="..\GIAN07\TAMA.H" />
+    <ClInclude Include="..\GIAN07\WindowCtrl.h" />
+    <ClInclude Include="..\GIAN07\WindowSys.h" />
+    <ClInclude Include="..\patch\LZ_UTY.h" />
+    <ClInclude Include="..\patch\MtoB.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/vs/秋霜玉.vcxproj.filters
+++ b/vs/秋霜玉.vcxproj.filters
@@ -1,0 +1,282 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;ipp;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\MAIN\MAIN.CPP">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\GIAN07\BOMBEFC.CPP">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\GIAN07\BOSS.CPP">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\GIAN07\DEMOPLAY.CPP">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\GIAN07\EFFECT.CPP">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\GIAN07\EFFECT3D.CPP">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\GIAN07\ENDING.CPP">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\GIAN07\ENEMY.CPP">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\GIAN07\EnemyExCtrl.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\GIAN07\FONTUTY.CPP">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\GIAN07\FRAGMENT.CPP">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\GIAN07\GAMEMAIN.CPP">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\GIAN07\GIAN.CPP">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\GIAN07\HOMINGL.CPP">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\GIAN07\ITEM.CPP">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\GIAN07\LASER.CPP">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\GIAN07\LENS.CPP">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\GIAN07\LLASER.CPP">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\GIAN07\LOADER.CPP">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\GIAN07\MAID.CPP">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\GIAN07\MAIDTAMA.CPP">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\GIAN07\PaletteEX.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\GIAN07\PRankCtrl.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\GIAN07\SCORE.CPP">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\GIAN07\SCROLL.CPP">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\GIAN07\TAMA.CPP">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\GIAN07\WindowCtrl.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\GIAN07\WindowSys.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\DirectXUTYs\D2_Polygon.CPP">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\DirectXUTYs\D3_TEX.CPP">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\DirectXUTYs\DD_CLIP2D.CPP">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\DirectXUTYs\DD_GRP2D.CPP">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\DirectXUTYs\DD_GRP3D.CPP">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\DirectXUTYs\DD_UTY.CPP">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\DirectXUTYs\DI_UTY.CPP">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\DirectXUTYs\DS_UTY.CPP">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\DirectXUTYs\DX_ERROR.C">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\DirectXUTYs\PBGMIDI.C">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\DirectXUTYs\UT_MATH.C">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\patch\MtoB.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\patch\LZ_UTY.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\GIAN07\BOMBEFC.H">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\GIAN07\BOSS.H">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\GIAN07\DEMOPLAY.H">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\GIAN07\ECL.H">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\GIAN07\ECL_LEN.H">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\GIAN07\EFFECT.H">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\GIAN07\EFFECT3D.H">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\GIAN07\ENDING.H">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\GIAN07\ENEMY.H">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\GIAN07\EnemyExCtrl.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\GIAN07\EXDEF.H">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\GIAN07\FONTUTY.H">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\GIAN07\FRAGMENT.H">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\GIAN07\GAMEMAIN.H">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\GIAN07\GIAN.H">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\GIAN07\HOMINGL.H">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\GIAN07\ITEM.H">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\GIAN07\LASER.H">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\GIAN07\LENS.H">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\GIAN07\LLASER.H">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\GIAN07\LOADER.H">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\GIAN07\MAID.H">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\GIAN07\MAIDTAMA.H">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\GIAN07\PaletteEx.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\GIAN07\PRankCtrl.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\GIAN07\SCL.H">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\GIAN07\SCORE.H">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\GIAN07\SCROLL.H">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\GIAN07\TAMA.H">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\GIAN07\WindowCtrl.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\GIAN07\WindowSys.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\DirectXUTYs\D2_Polygon.H">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\DirectXUTYs\D3_TEX.H">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\DirectXUTYs\DD_CLIP2D.H">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\DirectXUTYs\DD_GRP2D.H">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\DirectXUTYs\DD_GRP3D.H">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\DirectXUTYs\DD_UTY.H">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\DirectXUTYs\DI_UTY.H">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\DirectXUTYs\DS_UTY.H">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\DirectXUTYs\DX_ERROR.H">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\DirectXUTYs\DX_TYPE.H">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\DirectXUTYs\PBGMIDI.H">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\DirectXUTYs\PBGUTY_X.H">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\DirectXUTYs\UT_MATH.H">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\patch\LZ_UTY.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\patch\MtoB.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
This PR adds a visual studio solution to build the main part of the game.

Some source code is modified to fix build errors (mainly `char *` to `const char *`). Some missing header files and function implementations are included in the `patch` folder. There is still a function, namely `void PutSurfaceToBmp(GRP)`, that is not implemented. I think it is not essential for the program to run, so I just comment it out for now.

This PR is tested on VS2017 on Windows 10.17763. The build result can run with DAT files copied from the original game.

Sorry for writing the issue in English. I can understand Japanese but not good at writing. 翻訳が必要な場合は、お知らせください。